### PR TITLE
fixed reading .epub that are not compliant with standard

### DIFF
--- a/pkg/epub/epubxml.go
+++ b/pkg/epub/epubxml.go
@@ -31,9 +31,12 @@ type OCF struct {
 	} `xml:"rootfiles"`
 }
 
-// Get OPF file path fron OCF file
+// Get OPF file path from OCF file
 func GetOPFPath(zr *zip.ReadCloser) (string, error) {
-	f, _ := zr.Open("META-INF/container.xml")
+	f, zerr := zr.Open("META-INF/container.xml")
+	if zerr != nil {
+		return "", fmt.Errorf("failed to open ocf file: %w", zerr)
+	}
 	defer f.Close()
 	ocf := &OCF{}
 	if err := decodeXML(f, &ocf); err != nil {

--- a/pkg/epub/epubxml.go
+++ b/pkg/epub/epubxml.go
@@ -33,13 +33,13 @@ type OCF struct {
 
 // Get OPF file path from OCF file
 func GetOPFPath(zr *zip.ReadCloser) (string, error) {
-	f, zerr := zr.Open("META-INF/container.xml")
-	if zerr != nil {
-		return "", fmt.Errorf("failed to open ocf file: %w", zerr)
+	f, err := zr.Open("META-INF/container.xml")
+	if err != nil {
+		return "", err
 	}
 	defer f.Close()
 	ocf := &OCF{}
-	if err := decodeXML(f, &ocf); err != nil {
+	if err = decodeXML(f, &ocf); err != nil {
 		return "", err
 	}
 	return ocf.RootFiles.RootFile.FullPath, nil


### PR DESCRIPTION
now, the error of opening the META-INF/container.xml file is not ignored and panic is not caused by defered closing of an unopened file.


Attempt to close an unopened fs.File causes panic:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x93fa950]

goroutine 56 [running]:
github.com/vinser/flibgolite/pkg/epub.GetOPFPath(0xc00006a580?)
	/Users/sattellite/projects/flibgolite/pkg/epub/epubxml.go:37 +0x50
github.com/vinser/flibgolite/pkg/stock.(*Handler).indexEPUBFile(0xc000280060, {0xc00006a580, 0x7a})
	/Users/sattellite/projects/flibgolite/pkg/stock/stock.go:252 +0x105
github.com/vinser/flibgolite/pkg/stock.(*Handler).ScanDir.func2()
	/Users/sattellite/projects/flibgolite/pkg/stock/stock.go:150 +0xfc
created by github.com/vinser/flibgolite/pkg/stock.(*Handler).ScanDir in goroutine 54
	/Users/sattellite/projects/flibgolite/pkg/stock/stock.go:148 +0x445
```